### PR TITLE
fix: typo in model name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ async function loadModels(cv: any) {
 
   cv.FS_createDataFile('/', 'detect.prototxt', models.detect_prototxt, true, false, false)
   cv.FS_createDataFile('/', 'detect.caffemodel', models.detect_caffemodel, true, false, false)
-  cv.FS_createDataFile('/', 'sr.prototxt', models.detect_prototxt, true, false, false)
+  cv.FS_createDataFile('/', 'sr.prototxt', models.sr_prototxt, true, false, false)
   cv.FS_createDataFile('/', 'sr.caffemodel', models.sr_caffemodel, true, false, false)
 
   const qrcode_detector = new cv.wechat_qrcode_WeChatQRCode(


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix typo: `models.detect_prototxt` -> `models.sr_prototxt`.

Note that the `wechat_qrcode` will activate the super resolution model for (cropped) images with a width or height smaller than 320px. The typo results in an error in such circumstances due to the mismatched input blobs vector size.

![`blobs.size() < 2`](https://github.com/antfu/qr-scanner-wechat/assets/2606137/426026dd-5c38-4661-8bb6-37f97f9befb8)